### PR TITLE
fixed some missing country codes

### DIFF
--- a/osmnames/export_osmnames/functions.sql
+++ b/osmnames/export_osmnames/functions.sql
@@ -122,7 +122,7 @@ DROP FUNCTION IF EXISTS get_importance(INTEGER, VARCHAR, VARCHAR);
 CREATE FUNCTION get_importance(place_rank INT, wikipedia VARCHAR, country_code VARCHAR(2)) RETURNS DOUBLE PRECISION as $$
 DECLARE
   wiki_article_title TEXT;
-  wiki_article_language VARCHAR(2);
+  wiki_article_language VARCHAR;
   country_language_code VARCHAR(2);
   result double precision;
 BEGIN

--- a/osmnames/import_osm/create_hierarchy.sql
+++ b/osmnames/import_osm/create_hierarchy.sql
@@ -22,9 +22,8 @@ BEGIN
                                                AND country_code = country_code_in
                                                AND st_contains(geometry_in, geometry);
 END;
-
-
 $$ LANGUAGE plpgsql;
+
 DO $$
 BEGIN
   PERFORM set_parent_id_for_containing_entities(id, admin_level, country_code, geometry)

--- a/osmnames/import_osm/set_country_codes.sql
+++ b/osmnames/import_osm/set_country_codes.sql
@@ -1,5 +1,5 @@
-DROP FUNCTION IF EXISTS set_country_code_for_containing_entities(VARCHAR(2), geometry);
-CREATE FUNCTION set_country_code_for_containing_entities(country_code_in VARCHAR(2), geometry_value GEOMETRY) RETURNS VOID AS $$
+DROP FUNCTION IF EXISTS set_country_code_for_containing_elements(VARCHAR(2), geometry);
+CREATE FUNCTION set_country_code_for_containing_elements(country_code_in VARCHAR(2), geometry_value GEOMETRY) RETURNS VOID AS $$
 BEGIN
   UPDATE osm_linestring SET country_code = country_code_in WHERE country_code = '' IS NOT FALSE
                                                                  AND st_contains(geometry_value, geometry);
@@ -21,9 +21,14 @@ BEGIN
   -- use imported country code for polygons if present
   UPDATE osm_polygon SET country_code = lower(imported_country_code) WHERE imported_country_code IS NOT NULL;
 
-  -- use country grid to set country codes for everything else
-  PERFORM set_country_code_for_containing_entities(lower(country_code), geometry)
+  -- use country grid to set country codes for containing elements
+  PERFORM set_country_code_for_containing_elements(lower(country_code), geometry)
           FROM country_osm_grid
           ORDER BY area ASC;
+
+  -- finally use polygons with highest admin_levels for remaining elements without country_code
+  PERFORM set_country_code_for_containing_elements(lower(country_code), geometry)
+          FROM osm_polygon
+          WHERE admin_level <= 4;
 END
 $$ LANGUAGE plpgsql;

--- a/osmnames/import_osm/set_country_codes.sql
+++ b/osmnames/import_osm/set_country_codes.sql
@@ -1,5 +1,5 @@
-DROP FUNCTION IF EXISTS set_country_code_for_containing_elements(VARCHAR(2), geometry);
-CREATE FUNCTION set_country_code_for_containing_elements(country_code_in VARCHAR(2), geometry_value GEOMETRY) RETURNS VOID AS $$
+DROP FUNCTION IF EXISTS set_country_code_for_elements_within_geometry(VARCHAR(2), geometry);
+CREATE FUNCTION set_country_code_for_elements_within_geometry(country_code_in VARCHAR(2), geometry_value GEOMETRY) RETURNS VOID AS $$
 BEGIN
   UPDATE osm_linestring SET country_code = country_code_in WHERE country_code = '' IS NOT FALSE
                                                                  AND st_contains(geometry_value, geometry);
@@ -22,12 +22,12 @@ BEGIN
   UPDATE osm_polygon SET country_code = lower(imported_country_code) WHERE imported_country_code IS NOT NULL;
 
   -- use country grid to set country codes for containing elements
-  PERFORM set_country_code_for_containing_elements(lower(country_code), geometry)
+  PERFORM set_country_code_for_elements_within_geometry(lower(country_code), geometry)
           FROM country_osm_grid
           ORDER BY area ASC;
 
   -- finally use polygons with highest admin_levels for remaining elements without country_code
-  PERFORM set_country_code_for_containing_elements(lower(country_code), geometry)
+  PERFORM set_country_code_for_elements_within_geometry(lower(country_code), geometry)
           FROM osm_polygon
           WHERE admin_level <= 4;
 END

--- a/osmnames/import_osm/set_country_codes.sql
+++ b/osmnames/import_osm/set_country_codes.sql
@@ -18,6 +18,10 @@ $$ LANGUAGE plpgsql;
 
 DO $$
 BEGIN
+  -- use imported country code for polygons if present
+  UPDATE osm_polygon SET country_code = lower(imported_country_code) WHERE imported_country_code IS NOT NULL;
+
+  -- use country grid to set country codes for everything else
   PERFORM set_country_code_for_containing_entities(lower(country_code), geometry)
           FROM country_osm_grid
           ORDER BY area ASC;

--- a/tests/import_osm/test_set_country_codes.py
+++ b/tests/import_osm/test_set_country_codes.py
@@ -33,3 +33,18 @@ def test_osm_polygon_country_code_get_set_base_on_country_grid(session, schema, 
     set_country_codes()
 
     assert session.query(tables.osm_polygon).get(1).country_code == 'ch'
+
+
+def test_osm_polygon_country_code_get_set_bases_on_imported_country_code(session, schema, tables):
+    session.add(
+            tables.osm_polygon(
+                id=1,
+                imported_country_code='CH',
+            )
+        )
+
+    session.commit()
+
+    set_country_codes()
+
+    assert session.query(tables.osm_polygon).get(1).country_code == 'ch'

--- a/tests/import_osm/test_set_country_codes.py
+++ b/tests/import_osm/test_set_country_codes.py
@@ -48,3 +48,29 @@ def test_osm_polygon_country_code_get_set_bases_on_imported_country_code(session
     set_country_codes()
 
     assert session.query(tables.osm_polygon).get(1).country_code == 'ch'
+
+
+def test_osm_polygon_country_code_get_set_based_on_covering_polygon(session, schema, tables):
+    session.add(
+            tables.osm_polygon(
+                id=1,
+                name="Some Polygon with missing country_code",
+                geometry=WKTElement("POLYGON((1 1, 2 1, 2 2, 1 2,1 1))", srid=3857)
+            )
+        )
+
+    session.add(
+            tables.osm_polygon(
+                id=2,
+                name="Polygon with country_code covering the other polygon",
+                admin_level=4,
+                country_code='ch',
+                geometry=WKTElement("POLYGON((0 0,4 0,4 4,0 4,0 0))", srid=3857)
+            )
+        )
+
+    session.commit()
+
+    set_country_codes()
+
+    assert session.query(tables.osm_polygon).get(1).country_code == 'ch'


### PR DESCRIPTION
the first commit fixes a problem with wikipedia strings, which contained a more then two-characters "language". It can also be a [ITU](https://en.wikipedia.org/wiki/List_of_ITU_letter_codes).

With the second commit, more country codes are set with `set_country_code.sql`. The consistency checks have shown, that a lot of country_codes were missing (because not all elements are contained in a geometry of the country_osm_grid). That's why I added a command to set the country_code to the imported_country_code of imposm if it is present.

Finally country_codes are set, based on the already set country codes of the polygons.