### PR TITLE
duplicate streets

### DIFF
--- a/data/import/mapping.yml
+++ b/data/import/mapping.yml
@@ -208,8 +208,6 @@ tables:
       type: member_role
     - name: member_type
       type: member_type
-    - name: geometry
-      type: geometry
     - key: type
       name: relation_type
       type: string

--- a/osmnames/import_osm/merge_corresponding_linestrings.sql
+++ b/osmnames/import_osm/merge_corresponding_linestrings.sql
@@ -20,7 +20,7 @@ CREATE TABLE osm_merged_multi_linestring AS
     osm_linestring AS a,
     osm_linestring AS b
   WHERE
-    ST_Touches(a.geometry, b.geometry) AND
+    st_dwithin(a.geometry, b.geometry, 100) AND
     a.parent_id = b.parent_id AND
     a.parent_id IS  NOT NULL AND
     a.name = b.name AND

--- a/tests/import_osm/test_merge_corresponding_linestrings.py
+++ b/tests/import_osm/test_merge_corresponding_linestrings.py
@@ -107,6 +107,42 @@ def test_multiple_touching_linestrings_with_same_name_and_parent_id_get_merged(s
     assert session.query(tables.osm_linestring).get(4).merged, True
 
 
+def test_almost_touching_linestrings_with_same_name_and_parent_id_get_merged(session, schema, tables):
+    # the following geometries do not touch directly but has to be merged
+    session.add(
+            tables.osm_linestring(
+                id=1,
+                name="Oberseestrasse",
+                parent_id=1337,
+                country_code="ch",
+                osm_id=24055427,
+                geometry=WKTElement("""LINESTRING(981453.976751762
+                    5978726.11248254,981467.114366002 5978716.22031828,981491.02892942
+                    5978722.30674579,981536.264123906 5978726.22239555)""", srid=3857)
+            )
+        )
+
+    session.add(
+            tables.osm_linestring(
+                id=2,
+                name="Oberseestrasse",
+                parent_id=1337,
+                country_code="ch",
+                osm_id=308577271,
+                geometry=WKTElement("""LINESTRING(981558.359202398
+                    5978726.38726504,981674.610293174 5978708.37529047)""", srid=3857)
+            )
+        )
+
+    session.commit()
+
+    merge_corresponding_linestrings()
+
+    assert session.query(tables.osm_merged_multi_linestring).get(1).member_ids, [1, 2]
+    assert session.query(tables.osm_linestring).get(1).merged, True
+    assert session.query(tables.osm_linestring).get(2).merged, True
+
+
 def test_touching_linestrings_with_same_name_but_different_parent_id_dont_get_merged(session, schema, tables):
     session.add(
             tables.osm_linestring(


### PR DESCRIPTION
This PR fixes issue #74.

Linestrings are now merged when they:
* have the same parent_id (which can't be null)
* have the same name
* are near each other (100 meters) (before, they had to touch)

Since the parent_id still has to be the same, wrong linestrings are not merged accidentally. 