### PR TITLE
Consider merged streets

### DIFF
--- a/.env
+++ b/.env
@@ -3,5 +3,8 @@ PGHOST=postgres
 PGUSER=osm
 PGPASSWORD=osm
 
+# timezone e.g. for python logger
+TZ=Europe/Zurich
+
 DATA_DIR=/osmnames/data/
 PBF_FILE_URL=http://planet.osm.org/pbf/planet-latest.osm.pbf

--- a/osmnames/export_osmnames/create_linestrings_view.sql
+++ b/osmnames/export_osmnames/create_linestrings_view.sql
@@ -29,4 +29,4 @@ FROM
   osm_linestring,
   determine_class(type) AS class,
   get_parent_info(osm_linestring.name, parent_id, place_rank) AS parentInfo
-WHERE merged IS NOT TRUE;
+WHERE merged_into IS NULL;

--- a/osmnames/import_osm/create_custom_columns.sql
+++ b/osmnames/import_osm/create_custom_columns.sql
@@ -2,7 +2,7 @@ ALTER TABLE osm_linestring ADD COLUMN parent_id BIGINT;
 ALTER TABLE osm_linestring ADD COLUMN place_rank INTEGER;
 ALTER TABLE osm_linestring ADD COLUMN country_code VARCHAR(2);
 ALTER TABLE osm_linestring ADD COLUMN alternative_names TEXT;
-ALTER TABLE osm_linestring ADD COLUMN merged BOOL;
+ALTER TABLE osm_linestring ADD COLUMN merged_into BIGINT;
 
 ALTER TABLE osm_polygon ADD COLUMN parent_id BIGINT;
 ALTER TABLE osm_polygon ADD COLUMN place_rank INTEGER;

--- a/osmnames/import_osm/merge_corresponding_linestrings.sql
+++ b/osmnames/import_osm/merge_corresponding_linestrings.sql
@@ -31,9 +31,12 @@ CREATE TABLE osm_merged_multi_linestring AS
 
 ALTER TABLE osm_merged_multi_linestring ADD PRIMARY KEY (id);
 
+
+-- set merged to true for all merged linestrings
 DROP INDEX IF EXISTS idx_osm_linestring_merged_false;
 
-UPDATE osm_linestring SET merged = TRUE WHERE id IN
-  (SELECT unnest(member_ids) FROM osm_merged_multi_linestring);
+UPDATE osm_linestring SET merged_into = osm_merged_multi_linestring.id
+FROM osm_merged_multi_linestring
+WHERE osm_linestring.id = ANY(osm_merged_multi_linestring.member_ids);
 
-CREATE INDEX idx_osm_linestring_merged_false ON osm_linestring (merged) WHERE merged IS NOT TRUE;
+CREATE INDEX idx_osm_linestring_merged_false ON osm_linestring(merged_into) WHERE merged_into IS NULL;

--- a/osmnames/import_osm/set_housenumber_street_ids.sql
+++ b/osmnames/import_osm/set_housenumber_street_ids.sql
@@ -1,6 +1,5 @@
 UPDATE osm_housenumber AS housenumber
-  SET street_id = street.id
+  SET street_id = COALESCE(street.merged_into, street.id)
 FROM osm_linestring AS street
 WHERE street.parent_id = housenumber.parent_id
-      AND street.name = housenumber.street
-      AND street.merged IS NOT TRUE;
+      AND street.name = housenumber.street;

--- a/tests/import_osm/fixtures/test_prepare_imported_data.sql.dump
+++ b/tests/import_osm/fixtures/test_prepare_imported_data.sql.dump
@@ -18,7 +18,6 @@ SET search_path = public, pg_catalog;
 
 DROP INDEX IF EXISTS public.osm_relation_osm_id_idx;
 DROP INDEX IF EXISTS public.osm_relation_member_osm_id_idx;
-DROP INDEX IF EXISTS public.osm_relation_member_geom;
 DROP INDEX IF EXISTS public.osm_polygon_osm_id_idx;
 DROP INDEX IF EXISTS public.osm_polygon_geom;
 DROP INDEX IF EXISTS public.osm_point_osm_id_idx;
@@ -27,7 +26,16 @@ DROP INDEX IF EXISTS public.osm_linestring_osm_id_idx;
 DROP INDEX IF EXISTS public.osm_linestring_geom;
 DROP INDEX IF EXISTS public.osm_housenumber_osm_id_idx;
 DROP INDEX IF EXISTS public.osm_housenumber_geom;
+DROP INDEX IF EXISTS public.idx_osm_polygon_parent_id;
+DROP INDEX IF EXISTS public.idx_osm_polygon_country_code;
+DROP INDEX IF EXISTS public.idx_osm_point_parent_id;
+DROP INDEX IF EXISTS public.idx_osm_point_country_code;
+DROP INDEX IF EXISTS public.idx_osm_linestring_parent_id;
+DROP INDEX IF EXISTS public.idx_osm_linestring_name;
 DROP INDEX IF EXISTS public.idx_osm_linestring_merged_false;
+DROP INDEX IF EXISTS public.idx_osm_linestring_country_code;
+DROP INDEX IF EXISTS public.idx_osm_housenumber_parent_id;
+DROP INDEX IF EXISTS public.idx_osm_housenumber_country_code;
 DROP INDEX IF EXISTS public.idx_country_osm_grid_geometry;
 DROP INDEX IF EXISTS public.idx_country_name_country_code;
 ALTER TABLE IF EXISTS ONLY public.osm_relation DROP CONSTRAINT IF EXISTS osm_relation_pkey;
@@ -129,7 +137,7 @@ CREATE TABLE osm_linestring (
     place_rank integer,
     country_code character varying(2),
     alternative_names text,
-    merged boolean
+    merged_into bigint
 );
 
 
@@ -354,8 +362,7 @@ CREATE TABLE osm_relation_member (
     role character varying,
     member_type smallint,
     relation_type character varying,
-    name character varying,
-    geometry geometry(Geometry,3857)
+    name character varying
 );
 
 
@@ -499,10 +506,73 @@ CREATE INDEX idx_country_osm_grid_geometry ON country_osm_grid USING gist (geome
 
 
 --
+-- Name: idx_osm_housenumber_country_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_osm_housenumber_country_code ON osm_housenumber USING btree (country_code);
+
+
+--
+-- Name: idx_osm_housenumber_parent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_osm_housenumber_parent_id ON osm_housenumber USING btree (parent_id);
+
+
+--
+-- Name: idx_osm_linestring_country_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_osm_linestring_country_code ON osm_linestring USING btree (country_code);
+
+
+--
 -- Name: idx_osm_linestring_merged_false; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx_osm_linestring_merged_false ON osm_linestring USING btree (merged) WHERE (merged IS NOT TRUE);
+CREATE INDEX idx_osm_linestring_merged_false ON osm_linestring USING btree (merged_into) WHERE (merged_into IS NULL);
+
+
+--
+-- Name: idx_osm_linestring_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_osm_linestring_name ON osm_linestring USING btree (name);
+
+
+--
+-- Name: idx_osm_linestring_parent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_osm_linestring_parent_id ON osm_linestring USING btree (parent_id);
+
+
+--
+-- Name: idx_osm_point_country_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_osm_point_country_code ON osm_point USING btree (country_code);
+
+
+--
+-- Name: idx_osm_point_parent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_osm_point_parent_id ON osm_point USING btree (parent_id);
+
+
+--
+-- Name: idx_osm_polygon_country_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_osm_polygon_country_code ON osm_polygon USING btree (country_code);
+
+
+--
+-- Name: idx_osm_polygon_parent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_osm_polygon_parent_id ON osm_polygon USING btree (parent_id);
 
 
 --
@@ -559,13 +629,6 @@ CREATE INDEX osm_polygon_geom ON osm_polygon USING gist (geometry);
 --
 
 CREATE INDEX osm_polygon_osm_id_idx ON osm_polygon USING btree (osm_id);
-
-
---
--- Name: osm_relation_member_geom; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX osm_relation_member_geom ON osm_relation_member USING gist (geometry);
 
 
 --

--- a/tests/import_osm/prepare_housenumbers/test_set_street_ids.py
+++ b/tests/import_osm/prepare_housenumbers/test_set_street_ids.py
@@ -42,3 +42,14 @@ def test_when_street_with_same_name_but_different_parent_id_exists(session, sche
     set_street_ids()
 
     assert session.query(tables.osm_housenumber).get(1).street_id is None
+
+
+def test_when_merged_street_with_same_parent_id_and_name_exists(session, schema, tables):
+    session.add(tables.osm_housenumber(id=1, parent_id=1337, street="Haldenweg"))
+    session.add(tables.osm_linestring(id=42, merged_into=77, parent_id=1337, name="Haldenweg"))
+
+    session.commit()
+
+    set_street_ids()
+
+    assert session.query(tables.osm_housenumber).get(1).street_id == 77

--- a/tests/import_osm/test_merge_corresponding_linestrings.py
+++ b/tests/import_osm/test_merge_corresponding_linestrings.py
@@ -42,8 +42,8 @@ def test_touching_linestrings_with_same_name_and_parent_id_get_merged(session, s
     merge_corresponding_linestrings()
 
     assert session.query(tables.osm_merged_multi_linestring).get(1).member_ids, [1, 2]
-    assert session.query(tables.osm_linestring).get(1).merged, True
-    assert session.query(tables.osm_linestring).get(2).merged, True
+    assert session.query(tables.osm_linestring).get(1).merged_into, 1
+    assert session.query(tables.osm_linestring).get(2).merged_into, 1
 
 
 def test_multiple_touching_linestrings_with_same_name_and_parent_id_get_merged(session, schema, tables):
@@ -101,10 +101,10 @@ def test_multiple_touching_linestrings_with_same_name_and_parent_id_get_merged(s
     merge_corresponding_linestrings()
 
     assert session.query(tables.osm_merged_multi_linestring).get(1).member_ids, [1, 2, 3, 4]
-    assert session.query(tables.osm_linestring).get(1).merged, True
-    assert session.query(tables.osm_linestring).get(2).merged, True
-    assert session.query(tables.osm_linestring).get(3).merged, True
-    assert session.query(tables.osm_linestring).get(4).merged, True
+    assert session.query(tables.osm_linestring).get(1).merged_into, 1
+    assert session.query(tables.osm_linestring).get(2).merged_into, 1
+    assert session.query(tables.osm_linestring).get(3).merged_into, 1
+    assert session.query(tables.osm_linestring).get(4).merged_into, 1
 
 
 def test_almost_touching_linestrings_with_same_name_and_parent_id_get_merged(session, schema, tables):
@@ -139,8 +139,8 @@ def test_almost_touching_linestrings_with_same_name_and_parent_id_get_merged(ses
     merge_corresponding_linestrings()
 
     assert session.query(tables.osm_merged_multi_linestring).get(1).member_ids, [1, 2]
-    assert session.query(tables.osm_linestring).get(1).merged, True
-    assert session.query(tables.osm_linestring).get(2).merged, True
+    assert session.query(tables.osm_linestring).get(1).merged_into, 1
+    assert session.query(tables.osm_linestring).get(2).merged_into, 1
 
 
 def test_touching_linestrings_with_same_name_but_different_parent_id_dont_get_merged(session, schema, tables):
@@ -172,8 +172,8 @@ def test_touching_linestrings_with_same_name_but_different_parent_id_dont_get_me
 
     merge_corresponding_linestrings()
 
-    assert str(session.query(tables.osm_linestring).get(1).merged), False
-    assert str(session.query(tables.osm_linestring).get(2).merged), False
+    assert str(session.query(tables.osm_linestring).get(1).merged_into), False
+    assert str(session.query(tables.osm_linestring).get(2).merged_into), False
 
 
 def test_touching_linestrings_with_same_parent_id_but_different_name_dont_get_merged(session, schema, tables):
@@ -205,5 +205,5 @@ def test_touching_linestrings_with_same_parent_id_but_different_name_dont_get_me
 
     merge_corresponding_linestrings()
 
-    assert str(session.query(tables.osm_linestring).get(1).merged), False
-    assert str(session.query(tables.osm_linestring).get(2).merged), False
+    assert str(session.query(tables.osm_linestring).get(1).merged_into), False
+    assert str(session.query(tables.osm_linestring).get(2).merged_into), False


### PR DESCRIPTION
now street which has been merged are considered too when setting the street_ids for housenumbers.

This leads to more valid indexed housenumbers (Issue  #49)