### PR TITLE
Ensure tabs get deleted from names and alternative names

### DIFF
--- a/osmnames/import_osm/delete_unusable_entries.sql
+++ b/osmnames/import_osm/delete_unusable_entries.sql
@@ -3,11 +3,6 @@ DELETE FROM osm_polygon WHERE name = '' IS NOT FALSE;
 DELETE FROM osm_point WHERE name = '' IS NOT FALSE;
 DELETE FROM osm_linestring WHERE name = '' IS NOT FALSE;
 
--- remove tabs, so the export in tsv is valid
-UPDATE osm_polygon SET name =  regexp_replace(name,'\t', ' ') WHERE name LIKE '%'||chr(9)||'%';
-UPDATE osm_point SET name =  regexp_replace(name,'\t', ' ') WHERE name LIKE '%'||chr(9)||'%';
-UPDATE osm_linestring SET name =  regexp_replace(name,'\t', ' ') WHERE name LIKE '%'||chr(9)||'%';
-
 
 --delete entries with faulty geometries from import
 DELETE FROM osm_polygon WHERE ST_IsEmpty(geometry);

--- a/osmnames/import_osm/set_names.sql
+++ b/osmnames/import_osm/set_names.sql
@@ -3,12 +3,15 @@ CREATE FUNCTION get_alternative_names(all_tags HSTORE, name TEXT)
 RETURNS TEXT AS $$
 DECLARE
   alternative_names TEXT[];
+  alternative_names_string TEXT;
 BEGIN
   SELECT array_agg(DISTINCT(all_tags -> key))
   FROM unnest(akeys(all_tags)) AS key
-  WHERE (key LIKE 'name:%' OR key LIKE '%[_]name') AND (all_tags->key NOT ILIKE name)
+  WHERE (key LIKE 'name:%' OR key LIKE '%[_]name')
   INTO alternative_names;
-  RETURN COALESCE(array_to_string(alternative_names, ','), '');
+  alternative_names := array_remove(alternative_names, name);
+  alternative_names_string := array_to_string(alternative_names, ',');
+  RETURN COALESCE(regexp_replace(alternative_names_string, E'\\s+', ' ', 'g'), '');
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
@@ -16,14 +19,16 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 DROP FUNCTION IF EXISTS get_name(HSTORE);
 CREATE FUNCTION get_name(all_tags HSTORE)
 RETURNS TEXT AS $$
-  SELECT COALESCE(all_tags -> 'name:en',
+  SELECT COALESCE(
+                  all_tags -> 'name:en',
                   all_tags -> 'name:fr',
                   all_tags -> 'name:de',
                   all_tags -> 'name:es',
                   all_tags -> 'name:ru',
                   all_tags -> 'name:zh',
                   split_part(get_alternative_names(all_tags, ''), ',', 1),
-                  '');
+                  ''
+                  );
 $$ LANGUAGE 'sql' IMMUTABLE;
 
 
@@ -31,7 +36,10 @@ UPDATE osm_linestring SET name = get_name(all_tags) WHERE name = '' IS NOT FALSE
 UPDATE osm_polygon SET name = get_name(all_tags) WHERE name = '' IS NOT FALSE;
 UPDATE osm_point SET name = get_name(all_tags) WHERE name = '' IS NOT FALSE;
 
-
 UPDATE osm_linestring SET alternative_names = get_alternative_names(all_tags, name);
 UPDATE osm_polygon SET alternative_names = get_alternative_names(all_tags, name);
 UPDATE osm_point SET alternative_names = get_alternative_names(all_tags, name);
+
+UPDATE osm_linestring SET name =  regexp_replace(name, E'\\s+', ' ', 'g') WHERE name LIKE '%'||chr(9)||'%';
+UPDATE osm_polygon SET name =  regexp_replace(name, E'\\s+', ' ', 'g') WHERE name LIKE '%'||chr(9)||'%';
+UPDATE osm_point SET name =  regexp_replace(name, E'\\s+', ' ', 'g') WHERE name LIKE '%'||chr(9)||'%';

--- a/osmnames/import_osm/set_names.sql
+++ b/osmnames/import_osm/set_names.sql
@@ -40,6 +40,6 @@ UPDATE osm_linestring SET alternative_names = get_alternative_names(all_tags, na
 UPDATE osm_polygon SET alternative_names = get_alternative_names(all_tags, name);
 UPDATE osm_point SET alternative_names = get_alternative_names(all_tags, name);
 
-UPDATE osm_linestring SET name =  regexp_replace(name, E'\\s+', ' ', 'g') WHERE name LIKE '%'||chr(9)||'%';
-UPDATE osm_polygon SET name =  regexp_replace(name, E'\\s+', ' ', 'g') WHERE name LIKE '%'||chr(9)||'%';
-UPDATE osm_point SET name =  regexp_replace(name, E'\\s+', ' ', 'g') WHERE name LIKE '%'||chr(9)||'%';
+UPDATE osm_linestring SET name = regexp_replace(name, E'\\s+', ' ', 'g') WHERE name LIKE '%'||chr(9)||'%';
+UPDATE osm_polygon SET name = regexp_replace(name, E'\\s+', ' ', 'g') WHERE name LIKE '%'||chr(9)||'%';
+UPDATE osm_point SET name = regexp_replace(name, E'\\s+', ' ', 'g') WHERE name LIKE '%'||chr(9)||'%';

--- a/tests/import_osm/test_set_names.py
+++ b/tests/import_osm/test_set_names.py
@@ -101,3 +101,30 @@ def test_alternative_names_are_empty_if_only_name_is_present(session, schema, ta
     import_osm.set_names()
 
     assert session.query(tables.osm_point).get(4).alternative_names == ''
+
+
+def test_tabs_get_deleted_from_name(session, schema, tables):
+    session.add(
+        tables.osm_polygon(
+            id=3,
+            name="Lake\t\tZurich"
+            )
+        )
+    session.commit()
+    import_osm.set_names()
+
+    assert session.query(tables.osm_polygon).get(3).name == "Lake Zurich"
+
+
+def test_tabs_get_deleted_from_alternative_names(session, schema, tables):
+    session.add(
+        tables.osm_polygon(
+            id=4,
+            name = 'Bodensee',
+            all_tags={"name:en":"Lake         Constance","name:fr":"Lac\tde\tConstance" }            
+            )
+        )
+    session.commit()
+    import_osm.set_names()
+
+    assert session.query(tables.osm_polygon).get(4).alternative_names.count('\t') == 0


### PR DESCRIPTION
**Notes:**
1. In Postgresql 9.4 and above, the escape string syntax (E'...') must be used since backslash is treated as an ordinary character (Link to the [docs](https://www.postgresql.org/docs/9.4/static/runtime-config-compatible.html#GUC-STANDARD-CONFORMING-STRINGS)).
2. In `regexp_replace(name, E'\\s+', ' ', 'g')`
    * The `E'\\s+'` is to ensure that multiple consecutive tabs are handled as well.
    * The 'g' is to ensure that all tabs in the string are removed (not just the first occurence).
4. Moved the code to remove tabs from `delete_unusable_entries.sql` in `set_names.sql`, since we are not actually deleting those entries.  