### PR TITLE
use st_dwithin instead of parent_id to associate housenumbers to streets

### DIFF
--- a/osmnames/import_osm/merge_corresponding_linestrings.sql
+++ b/osmnames/import_osm/merge_corresponding_linestrings.sql
@@ -34,7 +34,6 @@ ALTER TABLE osm_merged_multi_linestring ADD PRIMARY KEY (id);
 
 -- drop not needed indexes
 DROP INDEX idx_osm_linestring_name;
-DROP INDEX osm_linestring_geom;
 DROP INDEX IF EXISTS idx_osm_linestring_merged_false;
 
 -- set merged_into for all merged linestrings

--- a/osmnames/import_osm/prepare_housenumbers/set_street_ids_by_street_name.sql
+++ b/osmnames/import_osm/prepare_housenumbers/set_street_ids_by_street_name.sql
@@ -1,12 +1,15 @@
 CREATE INDEX IF NOT EXISTS idx_osm_housenumber_normalized_street ON osm_housenumber(normalized_street);
 CREATE INDEX IF NOT EXISTS idx_osm_linestring_normalized_name ON osm_linestring(normalized_name);
-CREATE INDEX IF NOT EXISTS idx_osm_housenumber_parent_id ON osm_housenumber(parent_id);
+
+CLUSTER osm_linestring_geom ON osm_linestring;
+CLUSTER osm_housenumber_geom ON osm_housenumber;
 
 -- set street ids by fully matching names
 UPDATE osm_housenumber AS housenumber
   SET street_id = COALESCE(street.merged_into, street.osm_id)
 FROM osm_linestring AS street
-WHERE street.parent_id = housenumber.parent_id
+WHERE (street.parent_id = housenumber.parent_id
+        OR st_dwithin(street.geometry, housenumber.geometry, 1000))
       AND street.normalized_name = housenumber.normalized_street
       AND housenumber.street_id IS NULL;
 
@@ -14,7 +17,8 @@ WHERE street.parent_id = housenumber.parent_id
 UPDATE osm_housenumber AS housenumber
   SET street_id = COALESCE(street.merged_into, street.osm_id)
 FROM osm_linestring AS street
-WHERE street.parent_id = housenumber.parent_id
+WHERE (street.parent_id = housenumber.parent_id
+        OR st_dwithin(street.geometry, housenumber.geometry, 1000))
       AND levenshtein_less_equal(street.normalized_name, housenumber.normalized_street, 1) = 1
       AND housenumber.street_id IS NULL;
 
@@ -25,7 +29,8 @@ WHERE street.parent_id = housenumber.parent_id
 UPDATE osm_housenumber AS housenumber
   SET street_id = COALESCE(street.merged_into, street.osm_id)
 FROM osm_linestring AS street
-WHERE street.parent_id = housenumber.parent_id
+WHERE (street.parent_id = housenumber.parent_id
+        OR st_dwithin(street.geometry, housenumber.geometry, 1000))
       AND (street.normalized_name LIKE '%' || housenumber.normalized_street || '%'
            OR housenumber.normalized_street LIKE '%' || street.normalized_name || '%')
       AND housenumber.street_id IS NULL;

--- a/tests/import_osm/prepare_housenumbers/test_set_street_ids_by_street_name.py
+++ b/tests/import_osm/prepare_housenumbers/test_set_street_ids_by_street_name.py
@@ -1,7 +1,17 @@
 import os
 import pytest
+
+from geoalchemy2.elements import WKTElement
 from osmnames.database.functions import exec_sql_from_file
 from osmnames.import_osm.prepare_housenumbers import set_street_ids_by_street_name
+
+
+housenumber_geometry = WKTElement("""POLYGON((977335.866537083 5984030.73152414,977356.851263236
+                                     5984036.56047328,977357.448427519 5984021.10826761,977335.866537083
+                                     5984030.73152414))""", srid=3857)
+
+near_street_geometry = WKTElement("""LINESTRING(977437.841669201 5984049.19445902,977292.198898845
+                                     5984037.12412187)""", srid=3857)
 
 
 @pytest.fixture(scope="function")
@@ -10,9 +20,9 @@ def schema():
     exec_sql_from_file('../fixtures/test_prepare_imported_data.sql.dump', cwd=current_directory)
 
 
-def test_when_street_with_same_parent_id_and_name_exists(session, schema, tables):
-    session.add(tables.osm_housenumber(id=1, parent_id=1337, normalized_street="haldenweg"))
-    session.add(tables.osm_linestring(id=2, osm_id=42, parent_id=1337, normalized_name="haldenweg"))
+def test_when_near_street_with_same_name_exists(session, schema, tables):
+    session.add(tables.osm_housenumber(id=1, geometry=housenumber_geometry, normalized_street="haldenweg"))
+    session.add(tables.osm_linestring(id=2, osm_id=42, geometry=near_street_geometry, normalized_name="haldenweg"))
 
     session.commit()
 
@@ -21,9 +31,9 @@ def test_when_street_with_same_parent_id_and_name_exists(session, schema, tables
     assert session.query(tables.osm_housenumber).get(1).street_id == 42
 
 
-def test_when_street_with_same_parent_id_but_different_name_exists(session, schema, tables):
-    session.add(tables.osm_housenumber(id=1, parent_id=1337, normalized_street="haldenweg"))
-    session.add(tables.osm_linestring(id=2, osm_id=42, parent_id=1337, normalized_name="hornstrasse"))
+def test_when_near_street_with_different_name_exists(session, schema, tables):
+    session.add(tables.osm_housenumber(id=1, geometry=housenumber_geometry, normalized_street="haldenweg"))
+    session.add(tables.osm_linestring(id=2, osm_id=42, geometry=near_street_geometry, normalized_name="hornstrasse"))
 
     session.commit()
 
@@ -32,9 +42,12 @@ def test_when_street_with_same_parent_id_but_different_name_exists(session, sche
     assert session.query(tables.osm_housenumber).get(1).street_id is None
 
 
-def test_when_street_with_same_name_but_different_parent_id_exists(session, schema, tables):
-    session.add(tables.osm_housenumber(id=1, parent_id=1337, normalized_street="haldenweg"))
-    session.add(tables.osm_linestring(id=2, osm_id=42, parent_id=9999, normalized_name="haldenweg"))
+def test_when_far_away_street_with_same_name_exists(session, schema, tables):
+    far_away_street_geometry = WKTElement("""LINESTRING(978158.180417009 5981253.11872189,978262.432237961
+                                             5980562.33444262)""", srid=3857)
+
+    session.add(tables.osm_housenumber(id=1, geometry=housenumber_geometry, normalized_street="haldenweg"))
+    session.add(tables.osm_linestring(id=2, osm_id=42, geometry=far_away_street_geometry, normalized_name="haldenweg"))
 
     session.commit()
 
@@ -43,9 +56,9 @@ def test_when_street_with_same_name_but_different_parent_id_exists(session, sche
     assert session.query(tables.osm_housenumber).get(1).street_id is None
 
 
-def test_when_merged_street_with_same_parent_id_and_name_exists(session, schema, tables):
-    session.add(tables.osm_housenumber(id=1, parent_id=1337, normalized_street="haldenweg"))
-    session.add(tables.osm_linestring(id=2, osm_id=42, merged_into=77, parent_id=1337, normalized_name="haldenweg"))
+def test_when_near_merged_street_with_same_name_exists(session, schema, tables):
+    session.add(tables.osm_housenumber(id=1, geometry=housenumber_geometry, normalized_street="haldenweg"))
+    session.add(tables.osm_linestring(id=2, geometry=near_street_geometry, merged_into=77, normalized_name="haldenweg"))
 
     session.commit()
 
@@ -54,20 +67,20 @@ def test_when_merged_street_with_same_parent_id_and_name_exists(session, schema,
     assert session.query(tables.osm_housenumber).get(1).street_id == 77
 
 
-def test_when_street_with_same_parent_id_but_almost_same_name_exists(session, schema, tables):
-    session.add(tables.osm_housenumber(id=1, parent_id=1337, normalized_street="bochslensrasse"))
-    session.add(tables.osm_linestring(id=2, osm_id=42, parent_id=1337, normalized_name="bochslenstrasse"))
+def test_when_near_street_with_almost_same_name_exists(session, schema, tables):
+    session.add(tables.osm_housenumber(id=1, geometry=housenumber_geometry, normalized_street="bochslensrasse"))
+    session.add(tables.osm_linestring(id=2, osm_id=2, geometry=near_street_geometry, normalized_name="bochslenstrasse"))
 
     session.commit()
 
     set_street_ids_by_street_name()
 
-    assert session.query(tables.osm_housenumber).get(1).street_id == 42
+    assert session.query(tables.osm_housenumber).get(1).street_id == 2
 
 
 def test_when_street_name_contains_full_housenumber_street(session, schema, tables):
-    session.add(tables.osm_housenumber(id=1, parent_id=1337, osm_id=271182498, normalized_street="serre"))
-    session.add(tables.osm_linestring(id=2, osm_id=42, parent_id=1337, normalized_name="ruedelaserre"))
+    session.add(tables.osm_housenumber(id=1, geometry=housenumber_geometry, normalized_street="serre"))
+    session.add(tables.osm_linestring(id=2, osm_id=42, geometry=near_street_geometry, normalized_name="ruedelaserre"))
 
     session.commit()
 
@@ -77,8 +90,8 @@ def test_when_street_name_contains_full_housenumber_street(session, schema, tabl
 
 
 def test_when_housenumber_street_contains_full_street_name(session, schema, tables):
-    session.add(tables.osm_housenumber(id=1, parent_id=1337, osm_id=88267051, normalized_street="citepreville19"))
-    session.add(tables.osm_linestring(id=2, osm_id=42, parent_id=1337, normalized_name="citepreville"))
+    session.add(tables.osm_housenumber(id=1, geometry=housenumber_geometry, normalized_street="citepreville19"))
+    session.add(tables.osm_linestring(id=2, osm_id=42, geometry=near_street_geometry, normalized_name="citepreville"))
 
     session.commit()
 


### PR DESCRIPTION
since it takes the same amount of time but associates more housenumbers