### PR TITLE
Correct the name precedence (set name_en as default)

### DIFF
--- a/data/import/mapping.yml
+++ b/data/import/mapping.yml
@@ -8,7 +8,7 @@ tables:
       type: geometry
     - name: type
       type: mapping_value
-    - key: name
+    - key: name:en
       name: name
       type: string
     - key: null
@@ -71,7 +71,7 @@ tables:
       name: imported_country_code
       type: string
       key: ISO3166-1:alpha2
-    - key: name
+    - key: name:en
       name: name
       type: string
     - key: null
@@ -117,7 +117,7 @@ tables:
       type: geometry
     - name: type
       type: mapping_value
-    - key: name
+    - key: name:en
       name: name
       type: string
     - key: null
@@ -157,7 +157,6 @@ tables:
       - state
       - borough
       - district
-
       - ocean
       - sea
       - continent
@@ -196,7 +195,7 @@ tables:
     columns:
     - name: osm_id
       type: id
-    - key: name
+    - key: name:en
       name: name
       type: string
     - key: type
@@ -224,7 +223,7 @@ tables:
       name: relation_type
       type: string
     - name: name
-      key: name
+      key: name:en
       type: string
       from_member: true
     mapping:

--- a/osmnames/prepare_data/set_names/set_names_from_tags.sql
+++ b/osmnames/prepare_data/set_names/set_names_from_tags.sql
@@ -2,7 +2,7 @@ DROP FUNCTION IF EXISTS get_names(TEXT, HSTORE);
 CREATE FUNCTION get_names(current_name TEXT, all_tags HSTORE)
 RETURNS TABLE(name TEXT, alternative_names_string TEXT) AS $$
 DECLARE
-  accepted_name_tags TEXT[] := ARRAY['name:left','name:right','int_name','loc_name','nat_name',
+  accepted_name_tags TEXT[] := ARRAY['name','name:left','name:right','int_name','loc_name','nat_name',
                                      'official_name','old_name','reg_name','short_name','alt_name'];
   alternative_names TEXT[];
 BEGIN
@@ -14,7 +14,7 @@ BEGIN
   name := current_name;
   IF name = '' IS NOT FALSE THEN
     SELECT COALESCE(
-                  all_tags -> 'name:en',
+                  all_tags -> 'name',
                   all_tags -> 'name:fr',
                   all_tags -> 'name:de',
                   all_tags -> 'name:es',

--- a/tests/prepare_data/set_names/test_set_names_from_tags.py
+++ b/tests/prepare_data/set_names/test_set_names_from_tags.py
@@ -23,13 +23,13 @@ def test_name_get_set_from_all_tags(session, schema, tables):
 
 
 def test_name_get_set_according_to_priority(session, schema, tables):
-    # Where priority order is en, fr, de, es, ru, zh
+    # Where priority order is en, local_language, fr, de, es, ru, zh
 
     session.add(
       tables.osm_polygon(
           id=2,
           name="",
-          all_tags={"name:fr": "Lac Leman", "name:de": "Genfersee", "name:en": "Lake Geneva"}
+          all_tags={"name": "Lac Leman", "name:de": "Genfersee"}
         )
     )
     session.add(
@@ -42,7 +42,7 @@ def test_name_get_set_according_to_priority(session, schema, tables):
     session.commit()
     set_names_from_tags()
 
-    assert session.query(tables.osm_polygon).get(2).name == "Lake Geneva"
+    assert session.query(tables.osm_polygon).get(2).name == "Lac Leman"
     assert session.query(tables.osm_linestring).get(2).name == "Rhein"
 
 


### PR DESCRIPTION
Set **name_en** as default, thereby changing the name precedence back to _name_en, name, name_fr, name_de, name_es, name_ru, name_zh_ as before. (Solve issue #131)

Really sorry about this @sfkeller @klokan and @philippks. I should have checked with everyone before making the change. 