### PR TITLE
Install psycopg2 using pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
       libgeos-dev \
       postgresql-client-11 \
       python-pip \
-      python-psycopg2 \
  && ln -s /usr/lib/libgeos_c.so /usr/lib/libgeos.so \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Since pip 10, it is not possible to install a pip package through `psycopg2` and distutils. See [this comment](https://github.com/pypa/pip/issues/5247#issuecomment-381550610) to understand the situation.

Due to this new behaviour, the compilation of the container failed.

This edit remove the installation of `psycopg2` using distutils, preferring the installation through pip.