### PR TITLE
Increase shm size to avoid "could not resize shared memory segment" errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
   postgres:
     image: mdillon/postgis:11
+    shm_size: 256mb
     environment:
       - POSTGRES_PASSWORD
     ports:


### PR DESCRIPTION
Hi,
Since the recent switch to parallel SQL queries, I've been experiencing (random?) errors on the postgres docker instance. Here's an excerpt from my latest export (see line 4):

```
2019-05-15 00:27:28,552 - INFO - start executing sql file merge_corresponding_linestrings.sql
psql:/tmp/tmp.3mwFwWZ8Ut:1: NOTICE:  relation "osm_linestring_geom" already exists, skipping
psql:/tmp/tmp.hfJXzF1ddA:4: NOTICE:  table "osm_merged_linestring" does not exist, skipping
psql:/tmp/tmp.hfJXzF1ddA:29: ERROR:  could not resize shared memory segment "/PostgreSQL.1390429275" to 16777216 bytes: No space left on device
CONTEXT:  parallel worker
psql:/tmp/tmp.hxfCowZTbg:1: NOTICE:  index "idx_osm_linestring_merged_false" does not exist, skipping
psql:/tmp/tmp.9FdCyUEqSr:5: ERROR:  relation "osm_merged_linestring" does not exist
LINE 2: FROM osm_merged_linestring
             ^
Traceback (most recent call last):
  File "./run.py", line 30, in <module>
    run()
  File "./run.py", line 24, in run
    prepare_data()
  File "/osmnames/osmnames/prepare_data/prepare_data.py", line 21, in prepare_data
    merge_corresponding_linestrings()
  File "/osmnames/osmnames/prepare_data/prepare_data.py", line 75, in merge_corresponding_linestrings
    exec_sql_from_file("merge_corresponding_linestrings.sql", cwd=os.path.dirname(__file__), parallelize=True)
  File "/osmnames/osmnames/database/functions.py", line 20, in exec_sql_from_file
    ], stdout=open(os.devnull, 'w')
  File "/usr/lib/python3.5/subprocess.py", line 271, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['par_psql', '-v', 'ON_ERROR_STOP=1', '--username=osm', '--dbname=osm', '--file=/osmnames/osmnames/prepare_data/merge_corresponding_linestrings.sql']' returned non-zero exit status 3
```

This problem is documented on the [postgres docker caveats](https://hub.docker.com/_/postgres/#caveats) section and on their [Github page](https://github.com/docker-library/postgres/issues/416), so I went ahead and increased the shm size to 256mb as suggested (from the 64mb default). After this the export process works ok.