### PR TITLE
Updated Dockerfile, bumping Postgres, Go and Debian versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.19.3-bullseye
 
-ENV DEBIAN_FRONTEND noninteractive
+# ARG is only set for the build
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get install curl ca-certificates gnupg -y
+RUN apt-get update && apt-get install curl ca-certificates gnupg -y
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list && \
     curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,10 @@ services:
     env_file: .env
 
   postgres:
-    image: mdillon/postgis:11
-    shm_size: 256mb
+    image: postgis/postgis:13-3.3
+    shm_size: 512mb
     environment:
-      - POSTGRES_PASSWORD
+      - POSTGRES_HOST_AUTH_METHOD=trust
     ports:
       - "54320:5432"
     volumes:


### PR DESCRIPTION
### Issue

The docker build is currently broken as Postgresql.org have removed support for Debian (9/Stretch). 

> 2022-08-12: Debian stretch (9) is no longer supported and will be removed from apt.postgresql.org at the end of October
https://wiki.postgresql.org/wiki/Apt#News

### Options

You could keep using the archived versions, by modifying line 3 of the `./Dockerfile`

```
RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list && \
```
to
```
RUN echo 'deb http://apt-archive.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list && \
```

Or we could bump the versions up. I've experimented with bumping the versions up for Postgres, Go and Debian. This would allow us to take advantage of the various performance improvements of newer versions. Feel free to reject this though if you prefer the change above.

### Proposed Changes
1. Upgraded Go to version 1.19 (latest) and Debian to Bullseye (11)

2. Change postgresql-client to reference version 13 (Bullseye provides postgresql-client-13, stable)
https://packages.debian.org/bullseye/postgresql-client

3. Switch the go command to just 'go install' with '@latest'

4. Moved DEBIAN_FRONTEND=noninteractive to the top to keep the file cleaner. ARG's are only available to build so not leaked into the image.

```
ARG DEBIAN_FRONTEND=noninteractive
```
5. Moved the cleanup commands quoted below, to execute after the requirements install. `gcc` is required to build `psycopg2-binary`

```
RUN apt-get purge -y --auto-remove \
      g++ gcc libc6-dev make git \
      && rm -rf /var/lib/apt/lists/*
```

6. Removed the lock on the requirements as those versions are too old

7. Switched the Postgres GIS from mdillon/postgis (4 years old, https://hub.docker.com/r/mdillon/postgis/) to postgis/postgis (https://github.com/postgis/docker-postgis)

File image is 1.33GB

### Testing

Built locally on MacOS (Intel) and on AWS (ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2)

**Test building**
![image](https://user-images.githubusercontent.com/16667079/201890185-5f9a4c0a-b5e9-4b27-9324-5779106df247.png)

**Tested Matla (5mb)**
![image](https://user-images.githubusercontent.com/16667079/201914940-cb14b048-601d-43be-b539-338e0a69c4e5.png)
![image](https://user-images.githubusercontent.com/16667079/201915502-8d3aa1c9-5c4e-497d-bba5-b9c0213f1a81.png)


**Tested  Portugal (200mb)**
![image](https://user-images.githubusercontent.com/16667079/201908955-b5f974ba-beee-4314-a958-5749a6d312a4.png)

![image](https://user-images.githubusercontent.com/16667079/201935484-03ab5cee-3be4-4b22-9aa4-b82cc069e214.png)

