### PR TITLE
add missing permissions for Wikipedia import

### DIFF
--- a/osmnames/import_wikipedia/import_wikipedia.py
+++ b/osmnames/import_wikipedia/import_wikipedia.py
@@ -51,6 +51,7 @@ def _create_temporary_user_for_dump():
     query = """
         CREATE ROLE brian LOGIN PASSWORD 'brian';
         GRANT ALL PRIVILEGES ON DATABASE {database} to brian;
+        GRANT ALL ON SCHEMA public TO brian;
     """.format(database=settings.get("DB_NAME"))
 
     exec_sql(query, user="postgres")


### PR DESCRIPTION
Before:

```
2023-03-08 19:46:04,349 - INFO - run pg_restore -j 2 --verbose --dbname osm -U brian /osmnames/data/import//wikipedia_article.sql.bin
pg_restore: connecting to database for restore
pg_restore: processing item 2791 ENCODING ENCODING
pg_restore: processing item 2792 STDSTRINGS STDSTRINGS
pg_restore: processing item 362 TABLE wikipedia_article
pg_restore: creating TABLE "public.wikipedia_article"
pg_restore: while PROCESSING TOC:
pg_restore: from TOC entry 362; 1259 2164210 TABLE wikipedia_article brian
pg_restore: error: could not execute query: ERROR:  permission denied for schema public
LINE 1: CREATE TABLE wikipedia_article (
                     ^
```

After:
```
2023-03-08 19:47:52,194 - INFO - run pg_restore -j 2 --verbose --dbname osm -U brian /osmnames/data/import//wikipedia_article.sql.bin
pg_restore: connecting to database for restore
pg_restore: processing item 2791 ENCODING ENCODING
pg_restore: processing item 2792 STDSTRINGS STDSTRINGS
pg_restore: processing item 362 TABLE wikipedia_article
pg_restore: creating TABLE "public.wikipedia_article"
pg_restore: entering main parallel loop
...
```

(I added `--verbose` for debugging purposes)