### PR TITLE
make boolean configuration options behave like expected

### DIFF
--- a/osmnames/settings_default.py
+++ b/osmnames/settings_default.py
@@ -5,9 +5,9 @@ DB_NAME = 'osm'
 DB_USER = 'osm'
 DB_PASSWORD = 'osm'
 DB_SCHEMA = 'public'
-SKIP_VACUUM = os.getenv('SKIP_VACUUM', False)
+SKIP_VACUUM = os.getenv('SKIP_VACUUM') == 'True'
 VACUUM_JOBS = os.getenv('VACUUM_JOBS', 4)
-SKIP_WIKIPEDIA = os.getenv('SKIP_WIKIPEDIA', False)
+SKIP_WIKIPEDIA = os.getenv('SKIP_WIKIPEDIA') == 'True'
 
 DATA_DIR = '/osmnames/data/'
 IMPORT_DIR = '/osmnames/data/import/'


### PR DESCRIPTION
Technically the docs don't say that `SOME_VAR=False` is legal, but it also doesn't fail when handed this incorrect config. This patch makes the options behave more like a real boolean.