### PR TITLE
optimize merging corresponding linestrings

### DIFF
--- a/osmnames/prepare_data/merge_corresponding_linestrings.sql
+++ b/osmnames/prepare_data/merge_corresponding_linestrings.sql
@@ -38,9 +38,13 @@ DROP INDEX idx_osm_linestring_name; --&
 DROP INDEX osm_linestring_geom; --&
 DROP INDEX IF EXISTS idx_osm_linestring_merged_false; --&
 
+CREATE INDEX IF NOT EXISTS idx_osm_merged_linestring_member_ids ON osm_merged_linestring USING GIN(member_ids); --&
+
 -- set merged_into for all merged linestrings
 UPDATE osm_linestring SET merged_into = osm_merged_linestring.osm_id
 FROM osm_merged_linestring
-WHERE osm_linestring.id = ANY(osm_merged_linestring.member_ids);
+WHERE ARRAY[osm_linestring.id] <@ (osm_merged_linestring.member_ids);
 
-CREATE INDEX idx_osm_linestring_merged_false ON osm_linestring(merged_into) WHERE merged_into IS NULL;
+DROP INDEX idx_osm_merged_linestring_member_ids; --&
+
+CREATE INDEX idx_osm_linestring_merged_false ON osm_linestring(merged_into) WHERE merged_into IS NULL; --&


### PR DESCRIPTION
The previous method nested table scans, as shown by this `EXPLAIN`:

```
Update on osm_linestring  (cost=0.00..130892674.42 rows=0 width=0)
  ->  Nested Loop  (cost=0.00..130892674.42 rows=241865 width=20)
        Join Filter: (osm_linestring.id = ANY (osm_merged_linestring.member_ids))
        ->  Seq Scan on osm_linestring  (cost=0.00..13895.41 rows=216441 width=10)
        ->  Materialize  (cost=0.00..2377.80 rows=24187 width=45)
              ->  Seq Scan on osm_merged_linestring  (cost=0.00..2256.87 rows=24187 width=45)
JIT:
  Functions: 8
  Options: Inlining true, Optimization true, Expressions true, Deforming true
```

Adding the index and modifying the query to be able to take advantage of it leads to this query plan:

```
Update on osm_linestring  (cost=0.96..1177290.57 rows=0 width=0)
  ->  Nested Loop  (cost=0.96..1177290.57 rows=18173870 width=20)
        ->  Seq Scan on osm_linestring  (cost=0.00..22972.78 rows=150278 width=10)
        ->  Bitmap Heap Scan on osm_merged_linestring  (cost=0.96..6.47 rows=121 width=45)
              Recheck Cond: (ARRAY[osm_linestring.id] <@ member_ids)
              ->  Bitmap Index Scan on idx_osm_merged_linestring_member_ids  (cost=0.00..0.93 rows=121 width=0
                    Index Cond: (member_ids @> ARRAY[osm_linestring.id])
JIT:
  Functions: 7
  Options: Inlining true, Optimization true, Expressions true, Deforming true
```

For my bounding box and a modified `mapping.yaml`, this brings down execution time for this part from ~30mins to ~13sec.

I compared the tables for both variants; they are identical. Test suite passes, too.