### PR TITLE
optimize street.normalized_name = housenumber.normalized_street comparisons

### DIFF
--- a/osmnames/prepare_data/prepare_housenumbers/set_street_ids_by_street_name.sql
+++ b/osmnames/prepare_data/prepare_housenumbers/set_street_ids_by_street_name.sql
@@ -1,6 +1,7 @@
 CREATE INDEX IF NOT EXISTS osm_linestring_normalized_name ON osm_linestring(normalized_name); --&
 CREATE INDEX IF NOT EXISTS osm_linestring_normalized_name_trgm ON osm_linestring USING GIN(normalized_name gin_trgm_ops); --&
 CREATE INDEX IF NOT EXISTS osm_linestring_geometry ON osm_linestring USING GIST(geometry); --&
+CREATE INDEX IF NOT EXISTS osm_housenumber_normalized_street ON osm_housenumber(normalized_street); --&
 CREATE INDEX IF NOT EXISTS osm_housenumber_geometry_center ON osm_housenumber USING GIST(geometry_center); --&
 
 -- see https://www.postgresql.org/docs/9.6/static/pgtrgm.html for more information
@@ -67,4 +68,5 @@ UPDATE osm_housenumber
 
 DROP INDEX osm_linestring_normalized_name; --&
 DROP INDEX osm_linestring_normalized_name_trgm; --&
+DROP INDEX osm_housenumber_normalized_street; --&
 DROP INDEX osm_housenumber_geometry_center; --&


### PR DESCRIPTION
This speeds up the runtime of `set_street_ids_by_street_name.sql` slightly for my 112 MB .osm.pbf extract:

old time: 50s, 51s
new time: 35s, 37s

old query plan:
```
Update on osm_housenumber housenumber  (cost=123038.07..124556.64 rows=0 width=0)
  ->  Merge Join  (cost=123038.07..124556.64 rows=8677 width=20)
        Merge Cond: ((street.parent_id = housenumber.parent_id) AND (street.normalized_name = housenumber.normalized_street))
        ->  Sort  (cost=40517.14..40892.83 rows=150278 width=43)
              Sort Key: street.parent_id, street.normalized_name
              ->  Seq Scan on osm_linestring street  (cost=0.00..22971.78 rows=150278 width=43)
        ->  Sort  (cost=82520.91..82645.60 rows=49873 width=27)
              Sort Key: housenumber.parent_id, housenumber.normalized_street
              ->  Bitmap Heap Scan on osm_housenumber housenumber  (cost=1528.10..78629.33 rows=49873 width=27)
                    Recheck Cond: (street_id IS NULL)
                    Filter: (normalized_street <> ''::text)
                    ->  Bitmap Index Scan on osm_housenumber_street_id  (cost=0.00..1515.63 rows=50027 width=0)
                          Index Cond: (street_id IS NULL)
JIT:
  Functions: 19
  Options: Inlining false, Optimization false, Expressions true, Deforming true
```

new query plan:
```
Update on osm_housenumber housenumber  (cost=0.43..103922.86 rows=0 width=0)
  ->  Nested Loop  (cost=0.43..103922.86 rows=8662 width=20)
        ->  Seq Scan on osm_linestring street  (cost=0.00..22971.78 rows=150278 width=43)
        ->  Memoize  (cost=0.43..4.61 rows=1 width=27)
              Cache Key: street.parent_id, street.normalized_name
              Cache Mode: logical
              ->  Index Scan using osm_housenumber_normalized_street on osm_housenumber housenumber  (cost=0.42..4.60 rows=1 width=27)
                    Index Cond: (normalized_street = street.normalized_name)
                    Filter: ((street_id IS NULL) AND (normalized_street <> ''::text) AND (street.parent_id = parent_id))
JIT:
  Functions: 14
  Options: Inlining false, Optimization false, Expressions true, Deforming true
```