### PR TITLE
optimize wikipedia import

### DIFF
--- a/docs/implementation/import_wikipedia.rst
+++ b/docs/implementation/import_wikipedia.rst
@@ -9,9 +9,7 @@ Also, the same calculations are applied, to achieve the same results.
 The initialization of the database is skipped, if it is already present.
 
 The download and import of the wikipedia dump are skipped, if it is already
-present. Since the dump was created with the username `brian`, a temporary user
-is created to restore the dump, which is dropped after transferring the
-ownership to the `osm` user.
+present.
 
 .. note:: The wikipedia import can be skipped by setting the environment
   variable `SKIP_WIKIPEDIA` to `True` in the `.env` file.


### PR DESCRIPTION
- restoring articles and redirects in parallel saves time, since even with appropriate `max_parallel_maintenance_workers` values the CPU utilization is not maxed out, even on a low core system.
- not restoring `post-data` will skip restoring constraints and indexes:
  - Constraint `pagelinks_pkey` on `wikipedia_article` took a large chunk of restoration time. This is where most of the speedup comes from.
  - `idx_wikipedia_redirect_from_title` was immediately dropped anyway.
  - `idx_osm_id` on `wikipedia_article` is not restored, but it doesn't look like this index is needed.
- `--no-owner` is not strictly needed, but simplifies the import.

Without patch, it's approximately 10mins wall clock time:

```
2023-03-11 12:34:44,109 - INFO - run pg_restore -j 2 --dbname osm -U brian /osmnames/data/import//wikipedia_article.sql.bin
2023-03-11 12:43:05,323 - INFO - finished
2023-03-11 12:43:05,323 - INFO - run pg_restore -j 2 --dbname osm -U brian /osmnames/data/import//wikipedia_redirect.sql.bin
2023-03-11 12:44:16,545 - INFO - finished
```

With patch, down to approximately 2mins:

```
2023-03-11 14:36:10,457 - INFO - run pg_restore -j 2 --dbname osm --no-owner --section pre-data --section data /osmnames/data/import//wikipedia_article.sql.bin
2023-03-11 14:36:10,458 - INFO - run pg_restore -j 2 --dbname osm --no-owner --section pre-data --section data /osmnames/data/import//wikipedia_redirect.sql.bin
2023-03-11 14:36:24,940 - INFO - finished
2023-03-11 14:37:53,555 - INFO - finished
```