### PR TITLE
use hash to index Wikipedia titles

### DIFF
--- a/osmnames/import_wikipedia/import_wikipedia.py
+++ b/osmnames/import_wikipedia/import_wikipedia.py
@@ -70,11 +70,11 @@ def prepare_wikipedia_redirects():
             SET from_title = concat_ws(':', language, from_title),
                 to_title = concat_ws(':', language, to_title);
     """)
-    exec_sql("CREATE INDEX ON wikipedia_redirect(from_title)")
+    exec_sql("CREATE INDEX ON wikipedia_redirect USING hash(from_title);")
 
 
 def create_wikipedia_index():
-    exec_sql("CREATE INDEX idx_wikipedia_article_title ON wikipedia_article (title);")
+    exec_sql("CREATE INDEX idx_wikipedia_article_title ON wikipedia_article USING hash(title);")
 
 
 # this function should only be used, when the wikipedia import is skipped


### PR DESCRIPTION
Indexing `wikipedia_article` titles using a btree takes ~380s, whereas using a hash brings this down to ~142s. The index statistics from `pg_stat_user_indexes` are nearly the same:

```
btree:
idx_scan   idx_tup_read   idx_tup_fetch
132460     17174          17174

hash:
idx_scan   idx_tup_read   idx_tup_fetch
132458     17198          17198
```

The `create_*_view.sql` are the ones making use of Wikipedia and are slightly faster, too. So it seems that at least for my area, faster index creation is not paid with slower lookups down the line.

The numbers for `wikipedia_redirects` go in the same direction, though I didn't look as closely there.

Both together reduce wall clock time from ~704s to ~463s, on top of some of the other patches.