### PR TITLE
parallelize tasks in set_street_ids_by_street_name

### DIFF
--- a/osmnames/prepare_data/prepare_housenumbers/set_street_ids_by_street_name.sql
+++ b/osmnames/prepare_data/prepare_housenumbers/set_street_ids_by_street_name.sql
@@ -36,16 +36,17 @@ FROM osm_linestring AS street
 WHERE street.parent_id = housenumber.parent_id
       AND street.normalized_name = housenumber.normalized_street
       AND housenumber.street_id IS NULL
-      AND housenumber.normalized_street != '';
+      AND housenumber.normalized_street != ''; --&
 
 -- set street id by fully matching names within range
 UPDATE osm_housenumber AS housenumber
   SET street_id = COALESCE(street.merged_into, street.osm_id)
 FROM osm_linestring AS street
 WHERE st_dwithin(street.geometry, housenumber.geometry_center, 1000)
+      AND (street.parent_id = housenumber.parent_id) IS NOT TRUE
       AND street.normalized_name = housenumber.normalized_street
       AND housenumber.street_id IS NULL
-      AND housenumber.normalized_street != '';
+      AND housenumber.normalized_street != ''; --&
 
 -- set street id by best matching name within same parent
 UPDATE osm_housenumber

--- a/osmnames/prepare_data/prepare_housenumbers/set_street_ids_by_street_name.sql
+++ b/osmnames/prepare_data/prepare_housenumbers/set_street_ids_by_street_name.sql
@@ -43,6 +43,7 @@ UPDATE osm_housenumber AS housenumber
   SET street_id = COALESCE(street.merged_into, street.osm_id)
 FROM osm_linestring AS street
 WHERE st_dwithin(street.geometry, housenumber.geometry_center, 1000)
+      -- inverse of the condition in previous query; also selects rows where any parent_id is NULL
       AND (street.parent_id = housenumber.parent_id) IS NOT TRUE
       AND street.normalized_name = housenumber.normalized_street
       AND housenumber.street_id IS NULL


### PR DESCRIPTION
On small area:

```
Time (mean ± σ):     223.249 s ±  7.893 s    [User: 0.561 s, System: 0.092 s]
Range (min … max):   215.830 s … 231.544 s    3 runs

Time (mean ± σ):     208.339 s ±  3.704 s    [User: 0.544 s, System: 0.055 s]
Range (min … max):   204.102 s … 210.962 s    3 runs
```

On all of Germany the time spent in this file becomes 14911s, compared to 23714s or 24031s (cmp. https://github.com/OSMNames/OSMNames/pull/223#issuecomment-1466867852).

The additional condition is so indirect to account for `NULL`s.

On its own, the new query is less efficient than the old one. So running in sequence now takes more time than it used to, but in parallel the speedup more than makes up for it.