### PR TITLE
parallelize `set_geometry_centers.sql` update queries

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -240,6 +240,32 @@ Example use:
 
 
 
+Parallelizing UPDATE Queries
+****************************
+
+`PostgreSQL 15 doesn't parallelize UPDATE queries
+<https://www.postgresql.org/docs/current/when-can-parallel-query-be-used.html>`_,
+even if that would not be an issue for the queries run in OSMNames. A strategy
+is to work on multiple rows in parallel, by dividing the table and running many
+queries in parallel.
+
+To keep repetition low, the ``auto_modulo(column_name_here)`` function can be
+used (defined in `create_helper_functions.sql
+<https://github.com/OSMNames/OSMNames/blob/d0726a519608ed466b3a0097eaa7144a7ec8dcbd/osmnames/prepare_data/create_helper_functions.sql>`_).
+The query is duplicated automatically before being run (see `functions.py
+<https://github.com/OSMNames/OSMNames/blob/d0726a519608ed466b3a0097eaa7144a7ec8dcbd/osmnames/database/functions.py>`_).
+It uses par_sql as explained in the previous section. The ``--&`` suffix is
+optional. Only ``UPDATE`` queries are supported.
+
+Example use:
+
+.. code-block:: sql
+
+    UPDATE osm_linestring ... WHERE auto_modulo(osm_id);
+    UPDATE osm_linestring ... WHERE auto_modulo(osm_id); --&
+
+
+
 Tips
 *****
 These tips may help for efficient development:

--- a/osmnames/prepare_data/create_helper_functions.sql
+++ b/osmnames/prepare_data/create_helper_functions.sql
@@ -25,3 +25,12 @@ BEGIN
   RETURN names;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
+
+-- if parallelize=True is set from Python, the caller query will be duplicated
+-- to allow parallel execution
+CREATE OR REPLACE FUNCTION auto_modulo(id INT, divisor INT = 1, remain INT = 0)
+RETURNS boolean AS $$
+BEGIN
+  RETURN id % divisor = remain;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/osmnames/prepare_data/create_hierarchy/set_geometry_centers.sql
+++ b/osmnames/prepare_data/create_hierarchy/set_geometry_centers.sql
@@ -1,2 +1,2 @@
-UPDATE osm_linestring SET geometry_center = st_lineInterpolatePoint(geometry, 0.5); --&
-UPDATE osm_housenumber SET geometry_center = st_centroid(geometry); --&
+UPDATE osm_linestring SET geometry_center = st_lineInterpolatePoint(geometry, 0.5) WHERE auto_modulo(id); --&
+UPDATE osm_housenumber SET geometry_center = st_centroid(geometry) WHERE auto_modulo(id); --&

--- a/tests/test_automod.py
+++ b/tests/test_automod.py
@@ -1,0 +1,56 @@
+import textwrap
+
+from osmnames.database.functions import modify_sql_with_auto_modulo
+
+
+def test_modify_sql_with_auto_modulo():
+    assert clean(modify_sql_with_auto_modulo("""
+            UPDATE foo SET bar = baz WHERE auto_modulo(id);
+        """)) == clean("""
+            UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 0); --&
+            UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 1); --&
+            UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 2); --&
+            UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 3); --&
+            UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 4); --&
+            UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 5); --&
+            UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 6); --&
+            UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 7); --&
+        """)
+
+
+def test_modify_sql_with_auto_module_with_newlines():
+    assert clean(modify_sql_with_auto_modulo("""
+            UPDATE osm_polygon AS polygon
+            SET merged_osm_id = linked_node_osm_id,
+                all_tags = polygon.all_tags || linked_node_tags,
+                wikipedia = COALESCE(NULLIF(polygon.wikipedia, ''), linked_node_wikipedia),
+                wikidata = COALESCE(NULLIF(polygon.wikidata, ''), linked_node_wikidata)
+            FROM polygons_with_linked_by_relation_node
+            WHERE polygon_id = polygon.id AND auto_modulo(polygon.id);
+        """)).startswith(clean("""
+            UPDATE osm_polygon AS polygon
+            SET merged_osm_id = linked_node_osm_id,
+                all_tags = polygon.all_tags || linked_node_tags,
+                wikipedia = COALESCE(NULLIF(polygon.wikipedia, ''), linked_node_wikipedia),
+                wikidata = COALESCE(NULLIF(polygon.wikidata, ''), linked_node_wikidata)
+            FROM polygons_with_linked_by_relation_node
+            WHERE polygon_id = polygon.id AND auto_modulo(polygon.id, 8, 0); --&
+        """))
+
+
+def test_modify_sql_with_auto_modulo_ignores_normal_update_queries():
+    query = """
+    UPDATE osm_polygon AS polygon
+      SET merged_osm_id = linked_node_osm_id,
+          all_tags = polygon.all_tags || linked_node_tags,
+          wikipedia = COALESCE(NULLIF(polygon.wikipedia, ''), linked_node_wikipedia),
+          wikidata = COALESCE(NULLIF(polygon.wikidata, ''), linked_node_wikidata)
+      FROM polygons_with_linked_by_relation_node
+      WHERE polygon_id = polygon.id;
+    """
+
+    assert modify_sql_with_auto_modulo(query) == query
+
+
+def clean(str):
+    return textwrap.dedent(str).strip()


### PR DESCRIPTION
Most `UPDATE` queries in Postgres run sequentially (as of Postgres 15, docs "15.2. When Can Parallel Query Be Used?", see ➀). This means that many steps are not fully utilizing the available hardware, even when queries on different tables are run in parallel.

In OSMNames many `UPDATE` queries are suitable to parallelize by working on multiple rows at the same time. This PR splits tables using modulo, as that was the most straightforward way. The tooling around it is to avoid repetition in the SQL files, while still allow copy&pasting the query for experimentation outside of a full run.

This approach was the "least worst" I could come up with. Postgres table partitioning doesn't enable parallelization, nor are there any other Postgres native strategies for data modifying queries. Wrapping queries into a PSQL function and invoking that multiple times cuts down on the repetition, but it remains cumbersome. Using a regular expression to modify the queries isn't ideal, but the existing SQL grammar parsers either throw away par_sql's `--&` comments or make modification convoluted. For similar reasons I decided against a more sophisticated approach that would inline the modulo operation and do it with a PSQL function instead.

This PR just modifies `set_geometry_centers.sql` to see if you are okay with this approach in general, and because validating all modified queries takes some time.

The speedup is noticeable on small datasets, even though the two queries don't take up a lot of the runtime to begin with:

```
// master (full run)
Time (mean ± σ):     207.948 s ±  1.158 s    [User: 0.542 s, System: 0.078 s]
Range (min … max):   206.397 s … 209.194 s    4 runs

// patch (full run)
Time (mean ± σ):     204.852 s ±  1.053 s    [User: 0.525 s, System: 0.078 s]
Range (min … max):   203.285 s … 205.538 s    4 runs
```

Looking at just the two queries for a larger dataset (Germany) the speedup remains. The CPU is also utilized better, as one would expect.

```
// just set_geometry_centers.sql
branch  duration   cpu%
master      387s   ~11%
patch       231s   ~60%
```

The system running the tests has 4 physical (8 logical) cores, so it seems likely the bottleneck is now elsewhere than CPU speed. Obviously this is a tuning parameter, and I don't see the point in over-optimizing it to any particular system. It could be made configurable if it has a large impact for users.

➀: https://www.postgresql.org/docs/current/when-can-parallel-query-be-used.html