### PR TITLE
make `auto_modulo` use available CPUs while observing `max_connections`

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -266,6 +266,27 @@ Example use:
 
 
 
+Parallelization and PostgreSQL's ``max_connections``
+****************************************************
+
+In addition to the previously mentioned ``--&`` from ``par_psql`` and the
+``auto_modulo`` PSQL function, there is also a ``run_in_parallel`` Python
+function. All combined need to have less simultaneous connections to PostgreSQL
+than its configured ``max_connections``. As there is no queuing mechanism, any
+additional query will fail outright and halt processing.
+
+``auto_modulo`` implements a simple heuristic based on available CPUs, the
+``max_connections`` setting and a hardcoded value of the independent query
+parallelization. The intent is to utilize available hardware resources, while
+staying within ``max_connections`` limit in absence of a more sophisticated
+queuing mechanism.
+
+The user can control parallelization by tuning PostgreSQL's ``max_connections``
+config, as in addition to other tuning parameters. A developer increasing
+parallelism in the code should check if the heuristic needs to be adapted.
+
+
+
 Tips
 *****
 These tips may help for efficient development:

--- a/docs/others.rst
+++ b/docs/others.rst
@@ -13,10 +13,10 @@ Database Configuration
 ----------------------
 
 For better performance, the database needs to be configured according to the
-resources of the host system, the process runs on. A custom configuration can
-be added by creating a file `/docker-entrypoint-initdb.d/alter_system.sh`
-inside the postgres container and marking it as executable. The script is
-executed when restarting the database container.
+resources of the host system, the process runs on. A custom configuration can be
+added to ``data/postgres_config.sh`` which is mounted into the postgres
+container through ``docker_compose.yml``. The script is executed when restarting
+the database container.
 
 Here is an example for the content of the script:
 
@@ -48,7 +48,7 @@ Here is an example for the content of the script:
       alter system set log_temp_files = '1MB';
       alter system set log_timezone = 'UTC';
       alter system set maintenance_work_mem = '96GB';
-      alter system set max_connections = '20';
+      alter system set max_connections = '40';
       alter system set random_page_cost = '1.1';
       alter system set shared_buffers = '96GB';
       alter system set synchronous_commit = 'off';
@@ -67,6 +67,10 @@ Here is an example for the content of the script:
 
 Determining the best configuration for a host is not easy. A good starting
 point for that is `PgTune <https://pgtune.leopard.in.ua/>`_.
+
+Parallelization is limited by CPU count and PostgreSQL's ``max_connections``
+setting. As a rule of thumb ``max_connections = cpu_count * 3`` or greater is
+required to (try to) utilize all CPUs.
 
 tmpfs
 -----

--- a/tests/test_automod.py
+++ b/tests/test_automod.py
@@ -1,12 +1,10 @@
-import textwrap
-
 from osmnames.database.functions import modify_sql_with_auto_modulo
 
 
 def test_modify_sql_with_auto_modulo():
     assert clean(modify_sql_with_auto_modulo("""
             UPDATE foo SET bar = baz WHERE auto_modulo(id);
-        """)) == clean("""
+        """, 8)) == clean("""
             UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 0); --&
             UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 1); --&
             UPDATE foo SET bar = baz WHERE auto_modulo(id, 8, 2); --&
@@ -27,7 +25,7 @@ def test_modify_sql_with_auto_module_with_newlines():
                 wikidata = COALESCE(NULLIF(polygon.wikidata, ''), linked_node_wikidata)
             FROM polygons_with_linked_by_relation_node
             WHERE polygon_id = polygon.id AND auto_modulo(polygon.id);
-        """)).startswith(clean("""
+        """, 8)).startswith(clean("""
             UPDATE osm_polygon AS polygon
             SET merged_osm_id = linked_node_osm_id,
                 all_tags = polygon.all_tags || linked_node_tags,
@@ -49,8 +47,8 @@ def test_modify_sql_with_auto_modulo_ignores_normal_update_queries():
       WHERE polygon_id = polygon.id;
     """
 
-    assert modify_sql_with_auto_modulo(query) == query
+    assert modify_sql_with_auto_modulo(query, 8) == query
 
 
 def clean(str):
-    return textwrap.dedent(str).strip()
+    return "\n".join(line.strip() for line in str.strip().splitlines())


### PR DESCRIPTION
Ideally, par_psql would recognize when the connections are exhausted and wait until one frees before continuing. Currently it fails silently as par_psql doesn't check psql's exit codes. I have provided a fix for that, but honoring `max_connections` from par_psql is not straight forward -- or at least I don't see how.

The heuristic is an attempt at "good enough" that gets parallelization, ease of use from user perspective and avoids large scale refactoring in OSMNames. For latter, removing par_psql in favor of the Python `run_in_parallel` function seems most sensible, but it implies moving most of the queries around, or re-implementing par_psql's approach -- both high effort tasks. It seems more sensible to work on other optimization tasks with better effort/gain ratio first.

I bumped the default value for `max_connections` in the example to 40, as even my low-core system bumps into that limit when `auto_modulo`ing three already parallelized queries.