### PR TITLE
use `CREATE OR REPLACE FUNCTION` in favor of `DROP FUNCTION IF EXISTS`

### DIFF
--- a/osmnames/export_osmnames/functions.sql
+++ b/osmnames/export_osmnames/functions.sql
@@ -17,8 +17,7 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 
-DROP FUNCTION IF EXISTS get_parent_info(BIGINT, TEXT);
-CREATE FUNCTION get_parent_info(id BIGINT, name TEXT)
+CREATE OR REPLACE FUNCTION get_parent_info(id BIGINT, name TEXT)
 RETURNS parentInfo AS $$
 DECLARE
   retval parentInfo;
@@ -68,8 +67,7 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 
-DROP FUNCTION IF EXISTS get_country_name(VARCHAR);
-CREATE FUNCTION get_country_name(country_code_in VARCHAR(2)) returns TEXT as $$
+CREATE OR REPLACE FUNCTION get_country_name(country_code_in VARCHAR(2)) returns TEXT as $$
   SELECT COALESCE(name -> 'name:en',
                   name -> 'name',
                   name -> 'name:fr',
@@ -81,8 +79,7 @@ CREATE FUNCTION get_country_name(country_code_in VARCHAR(2)) returns TEXT as $$
 $$ LANGUAGE 'sql' IMMUTABLE;
 
 
-DROP FUNCTION IF EXISTS get_importance(INTEGER, VARCHAR, VARCHAR);
-CREATE FUNCTION get_importance(place_rank INT, wikipedia VARCHAR, country_code VARCHAR(2)) RETURNS DOUBLE PRECISION as $$
+CREATE OR REPLACE FUNCTION get_importance(place_rank INT, wikipedia VARCHAR, country_code VARCHAR(2)) RETURNS DOUBLE PRECISION as $$
 DECLARE
   wiki_article_title TEXT;
   wiki_article_language VARCHAR;
@@ -113,24 +110,21 @@ $$
 LANGUAGE plpgsql IMMUTABLE;
 
 
-DROP FUNCTION IF EXISTS get_country_language_code(VARCHAR);
-CREATE FUNCTION get_country_language_code(country_code_in VARCHAR(2)) RETURNS VARCHAR(2) AS $$
+CREATE OR REPLACE FUNCTION get_country_language_code(country_code_in VARCHAR(2)) RETURNS VARCHAR(2) AS $$
   SELECT lower(country_default_language_code)
          FROM country_name
          WHERE country_code = country_code_in LIMIT 1;
 $$ LANGUAGE 'sql' IMMUTABLE;
 
 
-DROP FUNCTION IF EXISTS get_housenumbers(BIGINT);
-CREATE FUNCTION get_housenumbers(osm_id_in BIGINT) RETURNS TEXT AS $$
+CREATE OR REPLACE FUNCTION get_housenumbers(osm_id_in BIGINT) RETURNS TEXT AS $$
   SELECT string_agg(housenumber, ', ' ORDER BY housenumber ASC)
     FROM osm_housenumber
     WHERE street_id = osm_id_in;
 $$ LANGUAGE 'sql' IMMUTABLE;
 
 
-DROP FUNCTION IF EXISTS get_bounding_box(GEOMETRY, TEXT, INTEGER);
-CREATE FUNCTION get_bounding_box(geom GEOMETRY, country_code TEXT, admin_level INTEGER)
+CREATE OR REPLACE FUNCTION get_bounding_box(geom GEOMETRY, country_code TEXT, admin_level INTEGER)
 RETURNS DECIMAL[] AS $$
 DECLARE
   bounding_box DECIMAL[];

--- a/osmnames/prepare_data/create_helper_functions.sql
+++ b/osmnames/prepare_data/create_helper_functions.sql
@@ -1,5 +1,4 @@
-DROP FUNCTION IF EXISTS normalize_string(TEXT);
-CREATE FUNCTION normalize_string(name TEXT)
+CREATE OR REPLACE FUNCTION normalize_string(name TEXT)
 RETURNS TEXT AS $$
 BEGIN
   RETURN unaccent(lower(regexp_replace(name, '[ ''-\.\(\)]', '', 'g')));
@@ -7,8 +6,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 
-DROP FUNCTION IF EXISTS get_names(HSTORE);
-CREATE FUNCTION get_names(all_tags HSTORE)
+CREATE OR REPLACE FUNCTION get_names(all_tags HSTORE)
 RETURNS TEXT[] AS $$
 DECLARE
   accepted_name_tags TEXT[] := ARRAY['name','name:left','name:right','int_name','loc_name','nat_name',

--- a/osmnames/prepare_data/create_hierarchy/set_housenumbers_parent_ids.sql
+++ b/osmnames/prepare_data/create_hierarchy/set_housenumbers_parent_ids.sql
@@ -1,5 +1,4 @@
-DROP FUNCTION IF EXISTS set_parent_id_for_housenumbers_within_geometry(BIGINT, geometry);
-CREATE FUNCTION set_parent_id_for_housenumbers_within_geometry(id_in BIGINT, geometry_in GEOMETRY)
+CREATE OR REPLACE FUNCTION set_parent_id_for_housenumbers_within_geometry(id_in BIGINT, geometry_in GEOMETRY)
 RETURNS VOID AS $$
 BEGIN
   UPDATE osm_housenumber SET parent_id = id_in WHERE parent_id IS NULL

--- a/osmnames/prepare_data/create_hierarchy/set_linestrings_parent_ids.sql
+++ b/osmnames/prepare_data/create_hierarchy/set_linestrings_parent_ids.sql
@@ -1,5 +1,4 @@
-DROP FUNCTION IF EXISTS set_parent_id_for_linestrings_within_geometry(BIGINT, geometry);
-CREATE FUNCTION set_parent_id_for_linestrings_within_geometry(id_in BIGINT, geometry_in GEOMETRY)
+CREATE OR REPLACE FUNCTION set_parent_id_for_linestrings_within_geometry(id_in BIGINT, geometry_in GEOMETRY)
 RETURNS VOID AS $$
 BEGIN
   UPDATE osm_linestring SET parent_id = id_in WHERE parent_id IS NULL

--- a/osmnames/prepare_data/create_hierarchy/set_polygons_parent_ids.sql
+++ b/osmnames/prepare_data/create_hierarchy/set_polygons_parent_ids.sql
@@ -1,5 +1,4 @@
-DROP FUNCTION IF EXISTS set_parent_id_for_polygons_within_geometry(BIGINT, INT, geometry);
-CREATE FUNCTION set_parent_id_for_polygons_within_geometry(id_in BIGINT, place_rank_in INT, geometry_in GEOMETRY)
+CREATE OR REPLACE FUNCTION set_parent_id_for_polygons_within_geometry(id_in BIGINT, place_rank_in INT, geometry_in GEOMETRY)
 RETURNS VOID AS $$
 BEGIN
   UPDATE osm_polygon SET parent_id = id_in WHERE parent_id IS NULL

--- a/osmnames/prepare_data/prepare_housenumbers/set_street_attributes_by_nearest_street.sql
+++ b/osmnames/prepare_data/prepare_housenumbers/set_street_attributes_by_nearest_street.sql
@@ -1,5 +1,4 @@
-DROP FUNCTION IF EXISTS nearest_street(BIGINT, geometry);
-CREATE FUNCTION nearest_street(parent_id_in BIGINT, geometry_in GEOMETRY)
+CREATE OR REPLACE FUNCTION nearest_street(parent_id_in BIGINT, geometry_in GEOMETRY)
 RETURNS TABLE(osm_id BIGINT, name VARCHAR) AS $$
 BEGIN
   RETURN QUERY

--- a/osmnames/prepare_data/prepare_housenumbers/set_street_ids_by_street_name.sql
+++ b/osmnames/prepare_data/prepare_housenumbers/set_street_ids_by_street_name.sql
@@ -6,8 +6,7 @@ CREATE INDEX IF NOT EXISTS osm_housenumber_geometry_center ON osm_housenumber US
 -- see https://www.postgresql.org/docs/9.6/static/pgtrgm.html for more information
 UPDATE pg_settings SET setting = '0.5' WHERE name = 'pg_trgm.similarity_threshold';
 
-DROP FUNCTION IF EXISTS best_matching_street_within_parent(BIGINT, GEOMETRY, VARCHAR);
-CREATE FUNCTION best_matching_street_within_parent(parent_id_in BIGINT, geometry_in GEOMETRY, name_in VARCHAR)
+CREATE OR REPLACE FUNCTION best_matching_street_within_parent(parent_id_in BIGINT, geometry_in GEOMETRY, name_in VARCHAR)
 RETURNS BIGINT AS $$
   SELECT COALESCE(merged_into, osm_id)
     FROM osm_linestring
@@ -18,8 +17,7 @@ RETURNS BIGINT AS $$
     LIMIT 1;
 $$ LANGUAGE 'sql' IMMUTABLE;
 
-DROP FUNCTION IF EXISTS best_matching_street_within_range(GEOMETRY, VARCHAR);
-CREATE FUNCTION best_matching_street_within_range(geometry_in GEOMETRY, name_in VARCHAR)
+CREATE OR REPLACE FUNCTION best_matching_street_within_range(geometry_in GEOMETRY, name_in VARCHAR)
 RETURNS BIGINT AS $$
   SELECT COALESCE(merged_into, osm_id)
     FROM osm_linestring

--- a/osmnames/prepare_data/set_country_codes.sql
+++ b/osmnames/prepare_data/set_country_codes.sql
@@ -1,5 +1,4 @@
-DROP FUNCTION IF EXISTS set_country_code_for_polygons_within_geometry(VARCHAR(2), geometry);
-CREATE FUNCTION set_country_code_for_polygons_within_geometry(country_code_in VARCHAR(2), geometry_value GEOMETRY) RETURNS VOID AS $$
+CREATE OR REPLACE FUNCTION set_country_code_for_polygons_within_geometry(country_code_in VARCHAR(2), geometry_value GEOMETRY) RETURNS VOID AS $$
 BEGIN
   UPDATE osm_polygon SET country_code = country_code_in WHERE country_code = '' IS NOT FALSE
                                                               AND st_contains(geometry_value, geometry);
@@ -7,8 +6,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 
-DROP FUNCTION IF EXISTS get_most_intersecting_country_code(geometry);
-CREATE FUNCTION get_most_intersecting_country_code(geometry_in GEOMETRY) RETURNS VARCHAR(2) AS $$
+CREATE OR REPLACE FUNCTION get_most_intersecting_country_code(geometry_in GEOMETRY) RETURNS VARCHAR(2) AS $$
 BEGIN
   RETURN(
     SELECT lower(country_code)

--- a/osmnames/prepare_data/set_names/set_names_from_tags.sql
+++ b/osmnames/prepare_data/set_names/set_names_from_tags.sql
@@ -1,5 +1,4 @@
-DROP FUNCTION IF EXISTS get_name_and_alternative_names(TEXT, HSTORE);
-CREATE FUNCTION get_name_and_alternative_names(current_name TEXT, all_tags HSTORE)
+CREATE OR REPLACE FUNCTION get_name_and_alternative_names(current_name TEXT, all_tags HSTORE)
 RETURNS TABLE(name TEXT, alternative_names_string TEXT) AS $$
 DECLARE
   alternative_names TEXT[];

--- a/osmnames/prepare_data/set_place_ranks.sql
+++ b/osmnames/prepare_data/set_place_ranks.sql
@@ -1,7 +1,6 @@
 /* See Nominatim functions.sql placex_insert() line 676 for determining ranks
    Reference: https://github.com/openstreetmap/Nominatim/blob/master/sql/functions.sql */
-DROP FUNCTION IF EXISTS get_place_rank(TEXT, INT);
-CREATE FUNCTION get_place_rank(type TEXT, admin_level INT DEFAULT NULL)
+CREATE OR REPLACE FUNCTION get_place_rank(type TEXT, admin_level INT DEFAULT NULL)
 RETURNS int AS $$
 BEGIN
   RETURN CASE


### PR DESCRIPTION
The behaviour is unchanged, except PostgreSQL doesn't print
```
NOTICE:  function set_country_code_for_polygons_within_geometry(pg_catalog.varchar,geometry) does not exist, skipping
```
and similar when a function doesn't already exist. This makes the log output less noisy and more readable.