### PR TITLE
parallelize set names from tags

### DIFF
--- a/osmnames/prepare_data/set_names/set_names_from_tags.sql
+++ b/osmnames/prepare_data/set_names/set_names_from_tags.sql
@@ -34,6 +34,6 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 
-UPDATE osm_linestring SET (name, alternative_names) = (SELECT * FROM get_name_and_alternative_names(name, all_tags)); --&
-UPDATE osm_polygon SET (name, alternative_names) = (SELECT * FROM get_name_and_alternative_names(name, all_tags)); --&
-UPDATE osm_point SET (name, alternative_names) = (SELECT * FROM get_name_and_alternative_names(name, all_tags)); --&
+UPDATE osm_linestring SET (name, alternative_names) = (SELECT * FROM get_name_and_alternative_names(name, all_tags)) WHERE auto_modulo(id); --&
+UPDATE osm_polygon SET (name, alternative_names) = (SELECT * FROM get_name_and_alternative_names(name, all_tags)) WHERE auto_modulo(id); --&
+UPDATE osm_point SET (name, alternative_names) = (SELECT * FROM get_name_and_alternative_names(name, all_tags)) WHERE auto_modulo(id); --&


### PR DESCRIPTION
It uses the previously introduced `auto_modulo` to parallelize all update queries. It saves ~45% on the wall clock time in `set_names_from_tags.sql` for Hamburg metropolitan area, across 4 runs on this dataset. I did not confirm this for a larger area, as the trend seems pretty clear judging from the small sample here and similar optimization I ran on the larger dataset (i.e. https://github.com/OSMNames/OSMNames/commit/29bbc538ce903f8998e953c4ce675b89e5fe334c ).