### PR TITLE
parallelize UPDATE queries using `auto_modulo` in `set_place_ranks`

### DIFF
--- a/osmnames/prepare_data/prepare_data.py
+++ b/osmnames/prepare_data/prepare_data.py
@@ -56,7 +56,7 @@ def delete_unusable_entries():
 
 
 def set_place_ranks():
-    exec_sql_from_file("set_place_ranks.sql", cwd=os.path.dirname(__file__))
+    exec_sql_from_file("set_place_ranks.sql", cwd=os.path.dirname(__file__), parallelize=True)
     vacuum_database()
 
 

--- a/osmnames/prepare_data/set_place_ranks.sql
+++ b/osmnames/prepare_data/set_place_ranks.sql
@@ -28,6 +28,6 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 
-UPDATE osm_polygon SET place_rank = get_place_rank(type, admin_level); --&
-UPDATE osm_linestring SET place_rank = get_place_rank(type, admin_level); --&
-UPDATE osm_point SET place_rank = get_place_rank(type, admin_level); --&
+UPDATE osm_polygon SET place_rank = get_place_rank(type, admin_level) WHERE auto_modulo(id); --&
+UPDATE osm_linestring SET place_rank = get_place_rank(type, admin_level) WHERE auto_modulo(id); --&
+UPDATE osm_point SET place_rank = get_place_rank(type, admin_level) WHERE auto_modulo(id); --&


### PR DESCRIPTION
Reduces wall clock time spent in `set_place_ranks` by ~41%, using 8 runs of Hamburg metropolitan area as dataset.