### PR TITLE
parallelize `set_street_attributes_by_nearest_street.sql` using `auto_modulo`

### DIFF
--- a/osmnames/prepare_data/prepare_housenumbers.py
+++ b/osmnames/prepare_data/prepare_housenumbers.py
@@ -33,7 +33,7 @@ def set_street_ids_by_street_name():
 
 
 def set_street_attributes_by_nearest_street():
-    exec_sql_from_file("set_street_attributes_by_nearest_street.sql", cwd=SQL_DIR)
+    exec_sql_from_file("set_street_attributes_by_nearest_street.sql", cwd=SQL_DIR, parallelize=True)
 
 
 def sanitize_housenumbers():

--- a/osmnames/prepare_data/prepare_housenumbers/set_street_attributes_by_nearest_street.sql
+++ b/osmnames/prepare_data/prepare_housenumbers/set_street_attributes_by_nearest_street.sql
@@ -14,4 +14,5 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 UPDATE osm_housenumber
   SET (street_id, street) = (SELECT * FROM nearest_street(parent_id, geometry))
 WHERE street_id IS NULL
-      AND parent_id IS NOT NULL;
+      AND parent_id IS NOT NULL
+      AND auto_modulo(id);


### PR DESCRIPTION
Using

```
DEBUG - System cpu_count=8, PostgreSQL max_connections=14, using 3 connections to parallelize auto_modulo UPDATE queries
```

achieves a modest speedup on germany.osm.pbf
```
// master
finished executing sql file set_street_attributes_by_nearest_street.sql (took 45.8s)
// branch
finished executing sql file set_street_attributes_by_nearest_street.sql (took 24.6s)
```

The speedup is also noticeable for smaller datasets, though I lost the log files for those.