### PR TITLE
parallelize `normalize_street_names.sql` using `auto_module.sql`

### DIFF
--- a/osmnames/prepare_data/prepare_housenumbers.py
+++ b/osmnames/prepare_data/prepare_housenumbers.py
@@ -25,7 +25,7 @@ def set_street_names_by_relation_attributes():
 
 
 def normalize_street_names():
-    exec_sql_from_file("normalize_street_names.sql", cwd=SQL_DIR)
+    exec_sql_from_file("normalize_street_names.sql", cwd=SQL_DIR, parallelize=True)
 
 
 def set_street_ids_by_street_name():

--- a/osmnames/prepare_data/prepare_housenumbers/normalize_street_names.sql
+++ b/osmnames/prepare_data/prepare_housenumbers/normalize_street_names.sql
@@ -1,2 +1,2 @@
-UPDATE osm_housenumber SET normalized_street = normalize_string(street); --&
-UPDATE osm_linestring SET normalized_name = normalize_string(name); --&
+UPDATE osm_housenumber SET normalized_street = normalize_string(street) WHERE auto_modulo(id); --&
+UPDATE osm_linestring SET normalized_name = normalize_string(name) WHERE auto_modulo(id); --&


### PR DESCRIPTION
for germany.osm.pbf:

```
// settings
System cpu_count=8, PostgreSQL max_connections=14, using 3 connections to parallelize auto_modulo UPDATE queries
// master
finished executing sql file normalize_street_names.sql (took 324.9s)
// branch
finished executing sql file normalize_street_names.sql (took 177.0s)
```

`auto_modulo` does have an impact, i.e. the speedup isn't solely from enabling `Parallelize=True` which was forgotten. I tested this with the smaller dataset for Hamburg metropolitan area:

```
sequential:   56s
parallelized: 37s
par+automod:  29s
```