### PR TITLE
fix: incorrect nz overrides

### DIFF
--- a/data/sql/admin_level_type_mapping.sql
+++ b/data/sql/admin_level_type_mapping.sql
@@ -1154,7 +1154,7 @@ au	6269038	city
 au	2646730	city
 au	2456176	city
 mx	1376330	city
-nz	2094141	city
+nz	17000522	city
 nz	4266321	city
 nz	1640161	city
 nz	2595124	city
@@ -1165,7 +1165,7 @@ nz	3440209	city
 nz	2731991	city
 nz	4266370	city
 nz	1656388	city
-nz	4266962	city
+nz	17000449	city
 nz	4266375	city
 dj	3725245	city
 gm	3214211	city


### PR DESCRIPTION
The current overrides end up removing the Auckland and Nelson regions.
I have updated the IDs to the correct relations.

The issue is this data comes from libpostal so rerunning the `convert_libpostal_yamls_to_sql_stdin.py` script will overwrite these changes. I've opened a PR with libpostal https://github.com/openvenues/libpostal/pull/651 so hopefully it will be merged but my previous PRs haven't been merged yet.